### PR TITLE
Vagrant and EPEL fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ Session.vim
 spec/fixtures
 .*.sw[a-z]
 *.un~
+.librarian/*
+.tmp/*
+.vagrant/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 bundler_args: --without development
 before_install: rm Gemfile.lock || true
+branches:
+  only:
+  - master
 rvm:
 - 1.9.3
 - 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,16 @@
 source "https://rubygems.org"
 
 puppetversion = ENV["PUPPET_VERSION"]
-gem "rake"
-gem "puppet-lint-unquoted_string-check"
-gem "rspec-puppet"
-gem "puppet-syntax"
-gem "rspec", "< 3.2.0"
-gem "puppet", puppetversion, :require => false
-gem "puppet-lint", ">= 0.3.2"
-gem "puppetlabs_spec_helper", ">= 0.1.0"
+
+group :test do
+    gem "json", "< 2.0.0"
+    gem "metadata-json-lint"
+    gem "puppet", puppetversion, :require => false
+    gem "puppet-lint", ">= 0.3.2"
+    gem "puppet-lint-unquoted_string-check"
+    gem "puppetlabs_spec_helper", ">= 0.1.0"
+    gem "puppet-syntax"
+    gem "rake"
+    gem "rspec", "< 3.2.0"
+    gem "rspec-puppet"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -39,9 +39,14 @@ exclude_paths = [
 PuppetLint.configuration.ignore_paths = exclude_paths
 PuppetSyntax.exclude_paths = exclude_paths
 
-desc "Run syntax, lint, and spec tests."
+task :metadata_lint do
+  sh "bundle exec metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, spec, and metadata tests."
 task :test => [
   :syntax,
   :lint,
   :spec,
+  :metadata_lint,
 ]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,30 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "puppetlabs/centos-7.2-64-nocm"
+  # config.vm.box_check_update = false
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+  # config.vm.network "private_network", ip: "192.168.33.10"
+  # config.vm.network "public_network"
+
+  config.vm.network "private_network", type: "dhcp",
+    virtualbox__intnet: "vboxnet1"
+
+  config.vm.hostname = "puppet-fail2ban.example.com"
+
+  config.vm.provider "virtualbox" do |vb|
+   vb.gui = false
+   vb.memory = "1024"
+   vb.name = "puppet-fail2ban"
+  end
+
+  config.vm.provision "file", source: "vagrant_files/Gemfile", destination: "/tmp/Gemfile"
+  config.vm.provision "file", source: "vagrant_files/Gemfile.lock", destination: "/tmp/Gemfile.lock"
+  config.vm.provision "file", source: "vagrant_files/hiera.yaml", destination: "/tmp/hiera.yaml"
+  config.vm.provision "shell", path: "vagrant_files/centos7-init.sh"
+
+  config.vm.synced_folder ".", "/etc/puppet/modules/fail2ban"
+
+  config.ssh.insert_key = false
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -428,6 +428,8 @@ class fail2ban (
 
   if $use_epel {
     $pkg_require = Class['Epel']
+
+    require ::epel
   } else {
     $pkg_require = undef
   }

--- a/metadata.json
+++ b/metadata.json
@@ -67,6 +67,10 @@
     {
       "name": "example42/monitor",
       "version_requirement": ">= 2.0.0"
+    },
+    {
+      "name": "stahnma/epel",
+      "version_requirement": ">= 1.0.0"
     }
   ]
 }

--- a/vagrant_files/Gemfile
+++ b/vagrant_files/Gemfile
@@ -1,0 +1,13 @@
+source 'https://rubygems.org'
+
+puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 3.3']
+gem 'facter', '>= 1.7.0'
+gem 'hiera-eyaml'
+gem 'librarian-puppet'
+gem 'puppet', puppetversion
+gem 'puppetlabs_spec_helper', '>= 0.1.0'
+gem 'puppet-lint', '>= 0.3.2'
+gem 'puppet-syntax'
+gem 'rake'
+gem 'requests'
+gem 'rspec-puppet'

--- a/vagrant_files/Gemfile.lock
+++ b/vagrant_files/Gemfile.lock
@@ -1,0 +1,86 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.2.8)
+    diff-lcs (1.2.5)
+    facter (2.4.6)
+      CFPropertyList (~> 2.2.6)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.0)
+      faraday (>= 0.7.4, < 0.10)
+    hiera (1.3.4)
+      json_pure
+    hiera-eyaml (2.1.0)
+      highline (~> 1.6.19)
+      trollop (~> 2.0)
+    highline (1.6.21)
+    json_pure (1.8.3)
+    librarian-puppet (2.2.3)
+      librarianp (>= 0.6.3)
+      puppet_forge (~> 2.1)
+      rsync
+    librarianp (0.6.3)
+      thor (~> 0.15)
+    metaclass (0.0.4)
+    minitar (0.5.4)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    multipart-post (2.0.0)
+    puppet (3.8.7)
+      CFPropertyList (~> 2.2.6)
+      facter (> 2.0, < 4)
+      hiera (>= 1.0, < 4)
+      json_pure
+    puppet-lint (1.1.0)
+    puppet-syntax (2.1.0)
+      rake
+    puppet_forge (2.2.1)
+      faraday (~> 0.9.0)
+      faraday_middleware (>= 0.9.0, < 0.11.0)
+      minitar
+      semantic_puppet (~> 0.1.0)
+    puppetlabs_spec_helper (1.1.1)
+      mocha
+      puppet-lint
+      puppet-syntax
+      rake
+      rspec-puppet
+    rake (11.1.2)
+    requests (1.0.0)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-puppet (2.4.0)
+      rspec
+    rspec-support (3.4.1)
+    rsync (1.0.9)
+    semantic_puppet (0.1.3)
+    thor (0.19.1)
+    trollop (2.1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  hiera-eyaml
+  librarian-puppet
+  puppet
+  puppet-lint
+  puppet-syntax
+  puppetlabs_spec_helper
+  rake
+  requests
+  rspec-puppet
+
+BUNDLED WITH
+   1.12.3

--- a/vagrant_files/centos7-init.sh
+++ b/vagrant_files/centos7-init.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+rpm -Uvh https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs
+yum -y install git puppet vim
+mv /tmp/Gemfile /etc/puppet/
+mv /tmp/Gemfile.lock /etc/puppet/
+mv /tmp/hiera.yaml /etc/puppet/
+mkdir -p /etc/puppet/hieradata
+mkdir -p /etc/puppet/modules
+gem install bundle rake --no-rdoc --no-ri
+/usr/local/bin/bundle config --global silence_root_warning 1
+pushd /etc/puppet
+/usr/local/bin/bundle install
+pushd modules/fail2ban
+rm -f Puppetfile.lock
+librarian-puppet install --verbose --path=/etc/puppet/modules
+popd
+popd

--- a/vagrant_files/hiera.yaml
+++ b/vagrant_files/hiera.yaml
@@ -1,0 +1,7 @@
+---
+:backends:
+    - yaml
+:hierarchy:
+    - global
+:yaml:
+    :datadir: /etc/puppet/hieradata


### PR DESCRIPTION
- Add to .gitignore
- Add Vagrant configs
- Add metadata.json checks in tests
- Restructure Gemfile
- require EPEL in init.pp now for RHEL
- Add EPEL module to metadata.json
- Manually install json < 2.0.0 in Gemfile to allow Ruby 1.9.3 tests to run on Travis
